### PR TITLE
v1.9.1

### DIFF
--- a/lib/src/components/data_table/data_table.dart
+++ b/lib/src/components/data_table/data_table.dart
@@ -557,6 +557,7 @@ class _ArDriveDataTableState<T extends IndexedItem>
   }) {
     setState(
       () {
+        final wasMultiSelecting = _isMultiSelecting;
         if (row != null && index != null) {
           _selectMultiSelectItem(row, index, value);
         }
@@ -565,12 +566,11 @@ class _ArDriveDataTableState<T extends IndexedItem>
             !value &&
             getMultiSelectBox().selectedItems.isEmpty) {
           _isMultiSelectingWithLongPress = false;
+        }
 
-          if (widget.onChangeMultiSelecting != null) {
-            widget.onChangeMultiSelecting!(_isMultiSelecting);
-          }
-
-          return;
+        if (wasMultiSelecting != _isMultiSelecting &&
+            widget.onChangeMultiSelecting != null) {
+          widget.onChangeMultiSelecting!(_isMultiSelecting);
         }
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ardrive_ui
 description: UI Design Library for the ArDrive Design System
 
-version: 1.9.0
+version: 1.9.1
 
 publish_to: "none"
 

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -16,7 +16,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.0"
+    version: "1.9.1"
   args:
     dependency: transitive
     description:

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -16,7 +16,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.8.0"
+    version: "1.9.0"
   args:
     dependency: transitive
     description:


### PR DESCRIPTION
### Release notes
- Fixes `ArDriveDataTable` multiselect events 

#### More info
ArDriveDataTable was not firing off the correct state when the user deselected the last checkbox in multiselect and when they did not have ctrl pressed. This checks the multiSelect state and, if it changes, fire it off when a check box state changes. 