### PR TITLE
v1.13.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ardrive_io:
     git:
       url: https://github.com/ar-io/ardrive_io.git
-      ref: v1.4.0
+      ref: PE-4896-drag-and-drop-applies-wrong-content-type-to-files
   auto_size_text: ^3.0.0
   desktop_drop: ^0.4.0
   dotted_border: ^2.0.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ flutter:
   fonts:
     - family:  ArDriveIcons
       fonts:
-        - asset: assets/fonts/ArDriveIcons.ttf\
+        - asset: assets/fonts/ArDriveIcons.ttf
     - family: Wavehaus
       fonts:
         - asset: assets/fonts/Wavehaus-28Thin.otf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ardrive_ui
 description: UI Design Library for the ArDrive Design System
 
-version: 1.13.0
+version: 1.13.1
 
 publish_to: "none"
 
@@ -37,7 +37,7 @@ flutter:
   fonts:
     - family:  ArDriveIcons
       fonts:
-        - asset: assets/fonts/ArDriveIcons.ttf
+        - asset: assets/fonts/ArDriveIcons.ttf\
     - family: Wavehaus
       fonts:
         - asset: assets/fonts/Wavehaus-28Thin.otf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ardrive_io:
     git:
       url: https://github.com/ar-io/ardrive_io.git
-      ref: PE-4896-drag-and-drop-applies-wrong-content-type-to-files
+      ref: v1.4.1
   auto_size_text: ^3.0.0
   desktop_drop: ^0.4.0
   dotted_border: ^2.0.0+3

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "v1.4.0"
-      resolved-ref: "487156d476ad1612967348e5ae154147e481a77f"
+      ref: PE-4896-drag-and-drop-applies-wrong-content-type-to-files
+      resolved-ref: "19616c9d8490db3a09b23292f36ee6480b7b7dc3"
       url: "https://github.com/ar-io/ardrive_io.git"
     source: git
-    version: "1.4.0"
+    version: "1.4.1"
   ardrive_ui:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.13.0"
+    version: "1.13.1"
   args:
     dependency: transitive
     description:


### PR DESCRIPTION
### Release Notes
- Uses a fixed version of `ardrive_io`: https://github.com/ar-io/ardrive_io/releases/tag/v1.4.1